### PR TITLE
FIX: fix the parse failure in some ROMs.

### DIFF
--- a/app/src/main/java/com/blanke/mdwechat/auto_search/Main.kt
+++ b/app/src/main/java/com/blanke/mdwechat/auto_search/Main.kt
@@ -39,7 +39,7 @@ class Main {
         Logs.i("class 总数= ${wxClasses.size}")
 
         val optimizedDirectoryFile = context.getDir("dex", 0)
-        val classLoader = DexClassLoader(path, optimizedDirectoryFile.absolutePath, null, context.classLoader)
+        val classLoader = DexClassLoader(path, optimizedDirectoryFile.absolutePath, null, ClassLoader.getSystemClassLoader())
         WechatGlobal.wxPackageName = apkMeta.packageName
         WechatGlobal.wxLoader = classLoader
         WechatGlobal.wxClasses = wxClasses.map { it.classType }


### PR DESCRIPTION
Both MDWechat and Wechat depends android-support, but the version may varies. When set MDWechat's classloader to the parent of WeChat classes, conflicts occurred.

2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err: java.lang.reflect.InvocationTargetException
2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err:     at java.lang.reflect.Method.invoke(Native Method)
2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err:     at com.blanke.mdwechat.auto_search.Main.execute(Main.kt:57)
2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err:     at com.blanke.mdwechat.auto_search.Main.access$execute(Main.kt:18)
2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err:     at com.blanke.mdwechat.auto_search.Main$main$1.invoke(Main.kt:25)
2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err:     at com.blanke.mdwechat.auto_search.Main$main$1.invoke(Main.kt:18)
2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err:     at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:18)
2018-12-08 16:05:17.156 2360-2570/com.blanke.mdwechat W/System.err: Caused by: java.lang.IncompatibleClassChangeError: Structural change of android.support.v7.app.AppCompatActivity is hazardous (/data/user/0/com.blanke.mdwechat/app_dex/base.dex at compile time, /data/app/com.blanke.mdwechat-2/oat/arm64/base.odex at runtime): Virtual method count off: 47 vs 38