### PR TITLE
FIX: 使用标准的方法判断 VirtualXposed 环境，避免其他环境（如太极）被误伤。

### DIFF
--- a/app/src/main/java/com/blanke/mdwechat/util/VXPUtils.kt
+++ b/app/src/main/java/com/blanke/mdwechat/util/VXPUtils.kt
@@ -5,9 +5,7 @@ object VXPUtils {
 
     // 必须主线程调用
     fun isVXPEnv(): Boolean {
-        val traces = Thread.currentThread().stackTrace
-        val allTraces = traces.joinToString { it.className }
-        return allTraces.contains("com.lody.virtual") || allTraces.contains("me.weishu.exposed")
+        return System.getProperty("vxp") != null
     }
 }
 


### PR DESCRIPTION
修复3.2 版本以上的MDWechat在太极中不生效的问题